### PR TITLE
fix: context loosing in startPublisher channel event handlers

### DIFF
--- a/providers/RabbitMQProducer.js
+++ b/providers/RabbitMQProducer.js
@@ -38,10 +38,10 @@ class RabbitMQProducer extends RabbitMQService {
   async startPublisher() {
     this._connection.createConfirmChannel((err, ch) => {
       if (this.closeOnErr(err)) return
-      ch.on('error', function(err) {
+      ch.on('error', (err) => {
         this.logger.error('[AMQP Producer] channel error', err.message)
       })
-      ch.on('close', function() {
+      ch.on('close', () => {
         this.logger.info('[AMQP Producer] channel closed')
       })
 

--- a/providers/RabbitMQProducer.js
+++ b/providers/RabbitMQProducer.js
@@ -10,8 +10,10 @@ class RabbitMQProducer extends RabbitMQService {
     exchange,
     routingKey,
     content,
-    { type = 'fanout', durable = false } = {}
+    options = {}
   ) {
+    const { type = 'fanout', durable = false } = options
+
     try {
       this._pubChannel.assertExchange(exchange, type, {
         durable
@@ -32,14 +34,14 @@ class RabbitMQProducer extends RabbitMQService {
       )
     } catch (e) {
       this.logger.error('[AMQP Producer] channel publish failure: ', e.message)
-      this._offlinePubQueue.push([exchange, routingKey, content])
+      this._offlinePubQueue.push([exchange, routingKey, content, options])
     }
   }
 
   sendPending() {
     if (this._offlinePubQueue.length > 0) {
-      var [exchange, routingKey, content] = this._offlinePubQueue.shift()
-      this.publish(exchange, routingKey, content)
+      var [exchange, routingKey, content, options] = this._offlinePubQueue.shift()
+      this.publish(exchange, routingKey, content, options)
     }
 
     setTimeout(() => this.sendPending(), 5000)


### PR DESCRIPTION
Because of using `function` instead of arrow func context is losed in handler, so this.logger.info is undefined.